### PR TITLE
Remove test prefixes from builders and tests

### DIFF
--- a/src/services/groups/__tests__/get-group-members.test.ts
+++ b/src/services/groups/__tests__/get-group-members.test.ts
@@ -103,13 +103,13 @@ describe('getGroupMembers service', () => {
           expect.arrayContaining([
             expect.objectContaining({
               id: testPerson1.id,
-              first_name: 'test_John',
-              last_name: 'test_Doe'
+              first_name: 'John',
+              last_name: 'Doe'
             }),
             expect.objectContaining({
               id: testPerson2.id,
-              first_name: 'test_Jane',
-              last_name: 'test_Smith'
+              first_name: 'Jane',
+              last_name: 'Smith'
             })
           ])
         );
@@ -186,8 +186,8 @@ describe('getGroupMembers service', () => {
 
         expect(result.data).toHaveLength(1);
         expect(result.data![0]).toMatchObject({
-          first_name: 'test_John',
-          last_name: 'test_Doe'
+          first_name: 'John',
+          last_name: 'Doe'
         });
       });
     });

--- a/src/services/messages/__tests__/get-initial-message.test.ts
+++ b/src/services/messages/__tests__/get-initial-message.test.ts
@@ -43,7 +43,7 @@ describe('get-initial-message-service', () => {
           expect(result.data).toHaveLength(1); // Initial messages for person
           const messages = result.data;
 
-          expect(messages?.[0]).toContain('test_John');
+          expect(messages?.[0]).toContain('John');
         });
       });
 

--- a/src/services/network/__tests__/get-network-activity.test.ts
+++ b/src/services/network/__tests__/get-network-activity.test.ts
@@ -67,8 +67,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Inner',
-            last_name: 'test_Five'
+            first_name: 'Inner',
+            last_name: 'Five'
           }
         });
 
@@ -76,8 +76,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Central',
-            last_name: 'test_Fifty'
+            first_name: 'Central',
+            last_name: 'Fifty'
           }
         });
 
@@ -177,8 +177,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Custom',
-            last_name: 'test_Period'
+            first_name: 'Custom',
+            last_name: 'Period'
           }
         });
 
@@ -265,8 +265,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Inner',
-            last_name: 'test_Five'
+            first_name: 'Inner',
+            last_name: 'Five'
           }
         });
 
@@ -274,8 +274,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Central',
-            last_name: 'test_Fifty'
+            first_name: 'Central',
+            last_name: 'Fifty'
           }
         });
 
@@ -283,8 +283,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Strategic',
-            last_name: 'test_Hundred'
+            first_name: 'Strategic',
+            last_name: 'Hundred'
           }
         });
 
@@ -292,8 +292,8 @@ describe('getNetworkActivity service', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_Everyone',
-            last_name: 'test_Else'
+            first_name: 'Everyone',
+            last_name: 'Else'
           }
         });
 

--- a/src/services/network/__tests__/get-todays-activity.test.ts
+++ b/src/services/network/__tests__/get-todays-activity.test.ts
@@ -117,8 +117,8 @@ describe('getTodaysActivity service', () => {
         expect(result.data?.inner5).toEqual({
           count: 2,
           people: expect.arrayContaining([
-            { name: 'test_John test_Doe' },
-            { name: 'test_Jane test_Smith' }
+            { name: 'John Doe' },
+            { name: 'Jane Smith' }
           ])
         });
         expect(result.data?.central50.count).toBe(0);
@@ -183,7 +183,7 @@ describe('getTodaysActivity service', () => {
         expect(result.data?.strategic100.count).toBe(0);
         expect(result.data?.everyone).toEqual({
           count: 1,
-          people: [{ name: 'test_Bob test_Custom' }]
+          people: [{ name: 'Bob Custom' }]
         });
       });
     });
@@ -310,19 +310,19 @@ describe('getTodaysActivity service', () => {
         expect(result.data).toEqual({
           inner5: {
             count: 1,
-            people: [{ name: 'test_Inner test_Five' }]
+            people: [{ name: 'Inner Five' }]
           },
           central50: {
             count: 1,
-            people: [{ name: 'test_Central test_Fifty' }]
+            people: [{ name: 'Central Fifty' }]
           },
           strategic100: {
             count: 1,
-            people: [{ name: 'test_Strategic test_Hundred' }]
+            people: [{ name: 'Strategic Hundred' }]
           },
           everyone: {
             count: 1,
-            people: [{ name: 'test_Every test_One' }]
+            people: [{ name: 'Every One' }]
           }
         });
       });
@@ -404,7 +404,7 @@ describe('getTodaysActivity service', () => {
         expect(result.error).toBeNull();
         expect(result.data?.inner5).toEqual({
           count: 4,
-          people: [{ name: 'test_Michael test_Dedup' }]
+          people: [{ name: 'Michael Dedup' }]
         });
         expect(result.data?.central50.count).toBe(0);
         expect(result.data?.strategic100.count).toBe(0);
@@ -528,8 +528,8 @@ describe('getTodaysActivity service', () => {
         expect(result.data?.inner5).toEqual({
           count: 6,
           people: expect.arrayContaining([
-            { name: 'test_Michael test_Multi' },
-            { name: 'test_Kendall test_Multi' }
+            { name: 'Michael Multi' },
+            { name: 'Kendall Multi' }
           ])
         });
         expect(result.data?.central50.count).toBe(0);

--- a/src/services/people/__tests__/get-people.test.ts
+++ b/src/services/people/__tests__/get-people.test.ts
@@ -55,13 +55,13 @@ describe('getPeople service', () => {
           expect.arrayContaining([
             expect.objectContaining({
               id: testPerson1.id,
-              first_name: 'test_John',
-              last_name: 'test_Doe'
+              first_name: 'John',
+              last_name: 'Doe'
             }),
             expect.objectContaining({
               id: testPerson2.id,
-              first_name: 'test_Jane',
-              last_name: 'test_Smith'
+              first_name: 'Jane',
+              last_name: 'Smith'
             })
           ])
         );
@@ -97,8 +97,8 @@ describe('getPeople service', () => {
 
         expect(result.data).toHaveLength(1);
         expect(result.data![0]).toMatchObject({
-          first_name: 'test_John',
-          last_name: 'test_Doe'
+          first_name: 'John',
+          last_name: 'Doe'
         });
       });
     });

--- a/src/services/people/__tests__/simple-search-people.test.ts
+++ b/src/services/people/__tests__/simple-search-people.test.ts
@@ -170,12 +170,12 @@ describe('searchPeople service', () => {
         expect(result.data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              first_name: 'test_Anthony',
-              last_name: 'test_Davis'
+              first_name: 'Anthony',
+              last_name: 'Davis'
             }),
             expect.objectContaining({
-              first_name: 'test_Anthony',
-              last_name: 'test_Edwards'
+              first_name: 'Anthony',
+              last_name: 'Edwards'
             })
           ])
         );
@@ -205,8 +205,8 @@ describe('searchPeople service', () => {
 
         expect(result1.data).toHaveLength(1);
         expect(result1.data![0]).toMatchObject({
-          first_name: 'test_Michael',
-          last_name: 'test_Jordan'
+          first_name: 'Michael',
+          last_name: 'Jordan'
         });
 
         // Should also find with full search term in bio
@@ -218,9 +218,9 @@ describe('searchPeople service', () => {
 
         expect(result2.data).toHaveLength(1);
         expect(result2.data![0]).toMatchObject({
-          first_name: 'test_Michael',
-          last_name: 'test_Jordan',
-          bio: 'test_Basketball legend'
+          first_name: 'Michael',
+          last_name: 'Jordan',
+          bio: 'Basketball legend'
         });
       });
     });

--- a/src/services/person-person/__tests__/get-person-person-relations.test.ts
+++ b/src/services/person-person/__tests__/get-person-person-relations.test.ts
@@ -23,8 +23,7 @@ describe('getPersonPersonRelations service', () => {
           user_id: testUser.id,
           first_name: 'Alice',
           last_name: 'Smith'
-        },
-        withPrefix: false
+        }
       });
       const personB = await createTestPerson({
         db,
@@ -32,8 +31,7 @@ describe('getPersonPersonRelations service', () => {
           user_id: testUser.id,
           first_name: 'Bob',
           last_name: 'Jones'
-        },
-        withPrefix: false
+        }
       });
       const personC = await createTestPerson({
         db,
@@ -41,8 +39,7 @@ describe('getPersonPersonRelations service', () => {
           user_id: testUser.id,
           first_name: 'Carol',
           last_name: 'Lee'
-        },
-        withPrefix: false
+        }
       });
 
       // Create two relations: A->B and C->A

--- a/src/services/person/__tests__/calculate-follow-up-score.test.ts
+++ b/src/services/person/__tests__/calculate-follow-up-score.test.ts
@@ -184,8 +184,8 @@ describe('calculateFollowUpScore', () => {
           expect.objectContaining({
             person: expect.objectContaining({
               id: person.id,
-              first_name: 'test_John',
-              last_name: 'test_Doe'
+              first_name: 'John',
+              last_name: 'Doe'
             }),
             interactions: expect.arrayContaining([
               expect.objectContaining({
@@ -243,8 +243,8 @@ describe('calculateFollowUpScore', () => {
           db,
           data: {
             user_id: testUser.id,
-            first_name: 'test_John',
-            last_name: 'test_Doe'
+            first_name: 'John',
+            last_name: 'Doe'
           }
         });
 

--- a/src/services/person/__tests__/create-interaction.test.ts
+++ b/src/services/person/__tests__/create-interaction.test.ts
@@ -61,7 +61,7 @@ describe('person-activity service', () => {
             payload: {
               personId: testPerson.id,
               userId: testUser.id,
-              personName: 'test_John test_Doe'
+              personName: 'John Doe'
             },
             options: {}
           });
@@ -116,7 +116,7 @@ describe('person-activity service', () => {
             payload: {
               personId: testPerson.id,
               userId: testUser.id,
-              personName: 'test_John test_Doe'
+              personName: 'John Doe'
             },
             options: {}
           });

--- a/src/services/person/__tests__/delete-person.test.ts
+++ b/src/services/person/__tests__/delete-person.test.ts
@@ -31,8 +31,7 @@ describe('person service', () => {
               user_id: testUser.id,
               first_name: 'John',
               last_name: 'Doe'
-            },
-            withPrefix: false
+            }
           });
 
           // Create another person for relationship

--- a/src/services/person/__tests__/format-person-summary.test.ts
+++ b/src/services/person/__tests__/format-person-summary.test.ts
@@ -293,7 +293,7 @@ describe('format-person-summary service', () => {
     } = options;
 
     // Always check for basic info
-    expect(summary).toContain('test_Darian test_Bajmanlou');
+    expect(summary).toContain('Darian Bajmanlou');
 
     // Check for optional content based on options
     if (includeGroups) {

--- a/src/services/person/__tests__/get-person.test.ts
+++ b/src/services/person/__tests__/get-person.test.ts
@@ -34,8 +34,8 @@ describe('getPerson service', () => {
 
         expect(result.data?.person).toMatchObject({
           id: testPerson.id,
-          first_name: 'test_John',
-          last_name: 'test_Doe'
+          first_name: 'John',
+          last_name: 'Doe'
         });
         expect(result.data?.contactMethods).toBeUndefined();
         expect(result.data?.addresses).toBeUndefined();

--- a/src/services/person/__tests__/update-person-details.test.ts
+++ b/src/services/person/__tests__/update-person-details.test.ts
@@ -14,9 +14,7 @@ import {
   updatePersonWebsite
 } from '../../person/update-person-details';
 
-// Helper to add test_ prefix for assertions
-const testPrefix = 'test_';
-const prefixed = (val: string) => `${testPrefix}${val}`;
+
 
 // Helper to create a test user and person
 async function setupUserAndPerson(db: SupabaseClient, personData: any = {}) {

--- a/src/services/tasks/__tests__/create-task.test.ts
+++ b/src/services/tasks/__tests__/create-task.test.ts
@@ -73,8 +73,8 @@ describe('createTask', () => {
         expect(createdTask.suggestedAction).toEqual(taskData.suggestedAction);
         expect(dateHandler(createdTask.end_at).isSame(dateHandler(taskData.endAt))).toBe(true);
         expect(createdTask.person.id).toBe(person.id);
-        expect(createdTask.person.first_name).toBe('test_John');
-        expect(createdTask.person.last_name).toBe('test_Doe');
+        expect(createdTask.person.first_name).toBe('John');
+        expect(createdTask.person.last_name).toBe('Doe');
       });
     });
 

--- a/src/services/tasks/__tests__/get-tasks.test.ts
+++ b/src/services/tasks/__tests__/get-tasks.test.ts
@@ -77,8 +77,8 @@ describe('getTasks service', () => {
           suggestedAction: taskData.suggestedAction,
           person: {
             id: testPerson.id,
-            first_name: 'test_John',
-            last_name: 'test_Doe'
+            first_name: 'John',
+            last_name: 'Doe'
           }
         });
       });
@@ -234,8 +234,8 @@ describe('getTasks service', () => {
         expect(result.error).toBeNull();
         expect(result.data).toHaveLength(1);
         expect(result.data![0].person).toMatchObject({
-          first_name: 'test_John',
-          last_name: 'test_Doe'
+          first_name: 'John',
+          last_name: 'Doe'
         });
       });
     });

--- a/src/services/tasks/generate-tasks/__tests__/generate-birthday-task.test.ts
+++ b/src/services/tasks/generate-tasks/__tests__/generate-birthday-task.test.ts
@@ -96,7 +96,7 @@ describe('generateBirthdayTasks', () => {
             personId: person1.id,
             trigger: TASK_TRIGGERS.BIRTHDAY_REMINDER.slug,
             endAt: dateHandler(birthdayInTwoWeeks).subtract(7, 'days').startOf('day').toISOString(),
-            context: expect.stringContaining('test_Alice has a birthday coming up')
+            context: expect.stringContaining('Alice has a birthday coming up')
           })
         );
 
@@ -107,7 +107,7 @@ describe('generateBirthdayTasks', () => {
             personId: person2.id,
             trigger: TASK_TRIGGERS.BIRTHDAY_REMINDER.slug,
             endAt: dateHandler(birthdayInAWeek).subtract(7, 'days').startOf('day').toISOString(),
-            context: expect.stringContaining('test_Bob has a birthday coming up')
+            context: expect.stringContaining('Bob has a birthday coming up')
           })
         );
       });

--- a/src/services/unipile/__tests__/search-people-linkedin.test.ts
+++ b/src/services/unipile/__tests__/search-people-linkedin.test.ts
@@ -26,8 +26,7 @@ describe('searchPerson service', () => {
             last_name: 'Doe',
             linkedin_public_id: 'john-doe-123',
             title: 'Software Engineer'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -62,8 +61,7 @@ describe('searchPerson service', () => {
             first_name: 'John',
             last_name: 'Doe',
             linkedin_public_id: 'john-doe-123'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -97,8 +95,7 @@ describe('searchPerson service', () => {
             first_name: 'John',
             last_name: 'Doe',
             linkedin_public_id: 'john-doe-123'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -151,8 +148,7 @@ describe('searchPerson service', () => {
             first_name: 'John',
             last_name: 'Doe',
             linkedin_public_id: 'john-doe-123'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -178,8 +174,7 @@ describe('searchPerson service', () => {
             first_name: 'Valerie',
             last_name: 'Soto M. Psych, MSpED.',
             linkedin_public_id: 'valeriesoto2025'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -213,8 +208,7 @@ describe('searchPerson service', () => {
             first_name: 'Valerie',
             last_name: 'Soto M. Psych, MSpED.',
             linkedin_public_id: 'valeriesoto2025'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({
@@ -248,8 +242,7 @@ describe('searchPerson service', () => {
             first_name: 'Valerie',
             last_name: 'Soto M. Psych, MSpED.',
             linkedin_public_id: 'valeriesoto2025'
-          },
-          withPrefix: false
+          }
         });
 
         const result = await searchPersonByNameAndLinkedInId({

--- a/src/tests/test-builder/create-person.ts
+++ b/src/tests/test-builder/create-person.ts
@@ -31,18 +31,15 @@ export interface TestPerson {
 export interface CreateTestPersonParams {
   db: DBClient;
   data: TestPerson;
-  withPrefix?: boolean;
 }
 
-export async function createTestPerson({ db, data, withPrefix = true }: CreateTestPersonParams) {
-  const testPrefix = withPrefix ? 'test_' : '';
-
+export async function createTestPerson({ db, data }: CreateTestPersonParams) {
   const { data: person, error } = await db
     .from('person')
     .insert({
-      first_name: `${testPrefix}${data.first_name}`,
-      last_name: `${testPrefix}${data.last_name}`,
-      bio: data.bio ? `${testPrefix}${data.bio}` : null,
+      first_name: data.first_name,
+      last_name: data.last_name,
+      bio: data.bio || null,
       user_id: data.user_id,
       birthday: data.birthday || null,
       completeness_score: data.completeness_score || null,
@@ -59,11 +56,11 @@ export async function createTestPerson({ db, data, withPrefix = true }: CreateTe
       data.contactMethods.map((cm) => ({
         person_id: person.id,
         user_id: data.user_id,
-        type: `${testPrefix}${cm.type}`,
-        value: `${testPrefix}${cm.value}`,
+        type: cm.type,
+        value: cm.value,
         is_primary: false,
         is_contact_method: true,
-        label: `${testPrefix}${cm.type}`
+        label: cm.type
       }))
     );
     if (contactError) throw contactError;
@@ -74,13 +71,13 @@ export async function createTestPerson({ db, data, withPrefix = true }: CreateTe
       data.addresses.map((addr) => ({
         person_id: person.id,
         user_id: data.user_id,
-        street: `${testPrefix}${addr.street}`,
-        city: `${testPrefix}${addr.city}`,
+        street: addr.street,
+        city: addr.city,
         state: addr.state,
         // postal_code: addr.postal_code,
-        country: `${testPrefix}${addr.country}`,
+        country: addr.country,
         is_primary: false,
-        label: `${testPrefix}${addr.type}`
+        label: addr.type
       }))
     );
     if (addressError) throw addressError;
@@ -91,8 +88,8 @@ export async function createTestPerson({ db, data, withPrefix = true }: CreateTe
       data.websites.map((web) => ({
         person_id: person.id,
         user_id: data.user_id,
-        url: `${testPrefix}${web.url}`,
-        label: `${testPrefix}${web.type}`,
+        url: web.url,
+        label: web.type,
         icon: web.type
       }))
     );


### PR DESCRIPTION
## Summary
- drop `withPrefix` option from the test person builder
- stop inserting `test_` prefixes when creating test people
- update all affected tests to expect unprefixed data

## Testing
- `yarn test` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6861f1cc9ac0832f9be14afe9d482d77