### PR TITLE
Add CSV import feature

### DIFF
--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server';
+
+import { apiResponse } from '@/lib/api-response';
+import { validateAuthentication } from '@/lib/auth/validate-authentication';
+import { toError } from '@/lib/errors';
+import { getFiles } from '@/services/files/get-files';
+import { importContactsTask } from '@/trigger/import-contacts';
+import { createClient } from '@/utils/supabase/server';
+
+export async function GET(req: NextRequest) {
+  const db = await createClient();
+  const authResult = await validateAuthentication(db);
+  if (authResult.error || !authResult.data) {
+    return apiResponse.unauthorized(toError(authResult.error));
+  }
+  const result = await getFiles({ db, userId: authResult.data.id });
+  if (result.error) return apiResponse.error(result.error);
+  return apiResponse.success(result.data);
+}
+
+export async function POST(req: NextRequest) {
+  const db = await createClient();
+  const authResult = await validateAuthentication(db);
+  if (authResult.error || !authResult.data) {
+    return apiResponse.unauthorized(toError(authResult.error));
+  }
+
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    return apiResponse.validationError(toError(new Error('File missing')));
+  }
+
+  // Placeholder upload logic - actual Supabase storage integration needed
+  const arrayBuffer = await file.arrayBuffer();
+  const path = `uploads/${Date.now()}-${file.name}`;
+  await db.storage.from('imports').upload(path, arrayBuffer);
+
+  const { data, error } = await db
+    .from('files')
+    .insert({ name: file.name, path, user_id: authResult.data.id })
+    .select()
+    .single();
+
+  if (error || !data) return apiResponse.error(toError(error));
+
+  await importContactsTask.trigger(
+    { userId: authResult.data.id, filePath: path },
+    { tags: [`user:${authResult.data.id}`] }
+  );
+
+  return apiResponse.success(data);
+}

--- a/src/app/app/settings/imports/page.tsx
+++ b/src/app/app/settings/imports/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useFiles } from '@/hooks/use-files';
+
+export default function ImportsPage() {
+  const { data: files, isLoading } = useFiles();
+
+  return (
+    <div className='mx-auto max-w-xl py-12'>
+      <h1 className='mb-6 text-2xl font-bold'>Imports</h1>
+      {isLoading ? (
+        <div>Loading...</div>
+      ) : (
+        <ul className='space-y-2'>
+          {files?.map((file) => (
+            <li key={file.id} className='border p-2 rounded'>
+              {file.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -95,6 +95,7 @@ export {
   Users,
   UserPlus,
   MessageCircle,
+  Upload,
   MoreHorizontal,
   Settings,
   Bookmark,

--- a/src/components/notifiers/jobs/import-contacts-notifier.tsx
+++ b/src/components/notifiers/jobs/import-contacts-notifier.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { JobStatusIcon } from '@/components/jobs/job-status-icon';
+import { formatJobTime, getJobStatusState } from '@/lib/jobs/status-utils';
+
+type ImportContactsJobProps = {
+  run: {
+    id: string;
+    status: string;
+    payload: { filePath: string };
+    createdAt: Date;
+  };
+};
+
+export function ImportContactsNotifier({ run }: ImportContactsJobProps) {
+  const { isExecuting } = getJobStatusState(run.status);
+  return (
+    <div className='flex w-full items-start gap-3 border-b bg-background px-4 py-3'>
+      <JobStatusIcon status={run.status} />
+      <div className='min-w-0 flex-1'>
+        <h4 className='truncate text-sm font-medium'>
+          {isExecuting ? 'Importing Contacts' : 'Contacts Imported'}
+        </h4>
+        <p className='text-sm text-muted-foreground'>{run.payload.filePath}</p>
+        <div className='mt-1 flex items-center justify-between'>
+          <span className='text-xs text-muted-foreground'>{formatJobTime(run.createdAt)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/people/people-header.tsx
+++ b/src/components/people/people-header.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import React from 'react';
+
 import { BaseHeader } from '@/components/headers/base-header';
-import { ListFilter, MoreHorizontal, Users } from '@/components/icons';
+import { ListFilter, MoreHorizontal, Upload, Users } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -15,6 +17,16 @@ interface PeopleHeaderProps {
 }
 
 export function PeopleHeader({ peopleCount }: PeopleHeaderProps) {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    await fetch('/api/files', { method: 'POST', body: formData });
+  };
+
   return (
     <BaseHeader className='flex flex-1 items-center justify-between'>
       <div className='flex items-center gap-3'>
@@ -36,6 +48,16 @@ export function PeopleHeader({ peopleCount }: PeopleHeaderProps) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <Button variant='outline' size='sm' onClick={() => fileInputRef.current?.click()}>
+          <Upload className='mr-2 size-4' /> Import CSV
+        </Button>
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept='.csv'
+          onChange={handleFileChange}
+          className='hidden'
+        />
       </div>
 
       <div className='flex items-center gap-2'>

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -14,6 +14,10 @@ const SETTINGS_SECTIONS = [
   {
     title: 'Integrations',
     href: routes.settings.integrations()
+  },
+  {
+    title: 'Imports',
+    href: routes.settings.imports()
   }
   // Add more sections here as needed
 ];

--- a/src/components/sidebar/jobs-popover.tsx
+++ b/src/components/sidebar/jobs-popover.tsx
@@ -11,6 +11,7 @@ import { BrainCog, Loader } from '@/components/icons';
 import { ActionPlanNotifier } from '@/components/notifiers/jobs/action-plan-notifier';
 import { SyncLinkedInConnectionsJobNotifier } from '@/components/notifiers/jobs/sync-linkedin-connections-notifier';
 import { UpdateAISummaryJobNotifier } from '@/components/notifiers/jobs/update-ai-summary-notifier';
+import { ImportContactsNotifier } from '@/components/notifiers/jobs/import-contacts-notifier';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { JOBS } from '@/lib/jobs/constants';
@@ -189,6 +190,9 @@ export function JobsPopover({ userId }: { userId: string }) {
               }
               if (run.taskIdentifier === JOBS.GENERATE_ACTION_PLAN) {
                 return <ActionPlanNotifier key={run.id} run={run} onClick={() => setIsOpen(false)} />;
+              }
+              if (run.taskIdentifier === JOBS.IMPORT_CONTACTS_CSV) {
+                return <ImportContactsNotifier key={run.id} run={run} />;
               }
               return null;
             })

--- a/src/hooks/use-files.ts
+++ b/src/hooks/use-files.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { errorToast } from '@/components/errors/error-toast';
+import { ApiResponse } from '@/types/api-response';
+
+type FileRow = Database['public']['Tables']['files']['Row'];
+
+export function useFiles() {
+  return useQuery<FileRow[]>({
+    queryKey: ['files'],
+    queryFn: async () => {
+      const res = await fetch('/api/files');
+      const json: ApiResponse<FileRow[]> = await res.json();
+      if (!res.ok || json.error) {
+        errorToast.show(json.error);
+        throw json.error;
+      }
+      return json.data || [];
+    }
+  });
+}

--- a/src/lib/jobs/constants.ts
+++ b/src/lib/jobs/constants.ts
@@ -4,5 +4,6 @@ export const JOBS = {
   HANDLE_INTERACTION_CREATED: 'handle-interaction-created',
   HANDLE_PERSON_SUMMARY_UPDATED: 'handle-person-summary-updated',
   SYNC_LINKEDIN_CONTACTS: 'sync-linkedin-contacts',
-  GENERATE_ACTION_PLAN: 'generate-action-plan'
+  GENERATE_ACTION_PLAN: 'generate-action-plan',
+  IMPORT_CONTACTS_CSV: 'import-contacts-csv'
 };

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -25,7 +25,8 @@ const PERSON_SEGMENTS = {
 
 const SETTINGS_SEGMENTS = {
   CUSTOM_FIELDS: 'custom-fields',
-  INTEGRATIONS: 'integrations'
+  INTEGRATIONS: 'integrations',
+  IMPORTS: 'imports'
 } as const;
 
 // Base path
@@ -84,7 +85,8 @@ export const routes = {
   settings: {
     root: () => `${BASE_PATH}/${APP_SEGMENTS.SETTINGS}`,
     customFields: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.CUSTOM_FIELDS}`,
-    integrations: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.INTEGRATIONS}`
+    integrations: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.INTEGRATIONS}`,
+    imports: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.IMPORTS}`
   },
 
   // Onboarding routes

--- a/src/services/files/__tests__/get-files.test.ts
+++ b/src/services/files/__tests__/get-files.test.ts
@@ -1,0 +1,25 @@
+import { getFiles, ERRORS } from '../get-files';
+
+describe('getFiles service', () => {
+  it('should return validation error when userId is missing', async () => {
+    // @ts-ignore - using empty object as DB client
+    const result = await getFiles({ db: {} as any, userId: '' });
+    expect(result.data).toBeNull();
+    expect(result.error).toEqual(ERRORS.FILES.MISSING_USER_ID);
+  });
+
+  it('should fetch files', async () => {
+    const mockSelect = jest.fn().mockReturnThis();
+    const mockEq = jest.fn().mockReturnThis();
+    const mockOrder = jest.fn().mockResolvedValue({ data: [{ id: '1' }], error: null });
+    const mockFrom = jest.fn(() => ({ select: mockSelect, eq: mockEq, order: mockOrder }));
+
+    const mockDb = { from: mockFrom } as any;
+    const result = await getFiles({ db: mockDb, userId: 'user1' });
+
+    expect(mockFrom).toHaveBeenCalledWith('files');
+    expect(mockOrder).toHaveBeenCalled();
+    expect(result.data).toEqual([{ id: '1' }]);
+    expect(result.error).toBeNull();
+  });
+});

--- a/src/services/files/get-files.ts
+++ b/src/services/files/get-files.ts
@@ -1,0 +1,54 @@
+import { createError, errorLogger } from '@/lib/errors';
+import { DBClient } from '@/types/database';
+import { ErrorType } from '@/types/errors';
+import { ServiceResponse } from '@/types/service-response';
+
+export const ERRORS = {
+  FILES: {
+    FETCH_ERROR: createError(
+      'files_fetch_error',
+      ErrorType.DATABASE_ERROR,
+      'Error fetching files',
+      'Unable to load files'
+    ),
+    MISSING_USER_ID: createError(
+      'missing_user_id',
+      ErrorType.VALIDATION_ERROR,
+      'User ID is required',
+      'User identifier is missing'
+    )
+  }
+};
+
+type FileRow = Database['public']['Tables']['files']['Row'];
+
+export interface GetFilesParams {
+  db: DBClient;
+  userId: string;
+}
+
+export async function getFiles({ db, userId }: GetFilesParams): Promise<ServiceResponse<FileRow[]>> {
+  try {
+    if (!userId) {
+      return { data: null, error: ERRORS.FILES.MISSING_USER_ID };
+    }
+
+    const { data, error } = await db
+      .from('files')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      const serviceError = ERRORS.FILES.FETCH_ERROR;
+      errorLogger.log(serviceError, { details: error });
+      return { data: null, error: serviceError };
+    }
+
+    return { data: data || [], error: null };
+  } catch (error) {
+    const serviceError = { ...ERRORS.FILES.FETCH_ERROR, details: error };
+    errorLogger.log(serviceError);
+    return { data: null, error: serviceError };
+  }
+}

--- a/src/trigger/import-contacts.ts
+++ b/src/trigger/import-contacts.ts
@@ -1,0 +1,17 @@
+import { task } from '@trigger.dev/sdk/v3';
+
+import { JOBS } from '@/lib/jobs/constants';
+import { importCSV } from '@/services/import/csv-import';
+import { createServiceRoleClient } from '@/utils/supabase/service-role';
+
+export const importContactsTask = task({
+  id: JOBS.IMPORT_CONTACTS_CSV,
+  run: async ({ userId, filePath }: { userId: string; filePath: string }) => {
+    const supabase = await createServiceRoleClient();
+    const result = await importCSV({ db: supabase, userId, filePath });
+    if (result.error) {
+      console.error('CSV import failed', result.error);
+    }
+    return result;
+  }
+});

--- a/src/types/database/supabase.ts
+++ b/src/types/database/supabase.ts
@@ -314,6 +314,30 @@ export type Database = {
           }
         ];
       };
+      files: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          path: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          path: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          path?: string;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       group: {
         Row: {
           created_at: string;


### PR DESCRIPTION
## Summary
- add Upload icon usage for CSV import in people header
- create files API route to store uploads and trigger background job
- implement React hook for fetching user files
- add imports section to settings navigation and page
- support import notifications in jobs popover
- register new trigger task and job constant
- add getFiles service with tests
- extend Supabase types with `files` table

## Testing
- `yarn test` *(fails: Missing required environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6862e1e2f5ec832fbf12ece78899d358