### PR TITLE
Add avatar upload support

### DIFF
--- a/src/app/api/person/[id]/avatar/route.ts
+++ b/src/app/api/person/[id]/avatar/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server';
+
+import { apiResponse } from '@/lib/api-response';
+import { validateAuthentication } from '@/lib/auth/validate-authentication';
+import { toError } from '@/lib/errors';
+import { updatePersonAvatar } from '@/services/person/update-person-avatar';
+import { createClient } from '@/utils/supabase/server';
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const supabase = await createClient();
+  const authResult = await validateAuthentication(supabase);
+  if (authResult.error || !authResult.data) {
+    return apiResponse.unauthorized(toError(authResult.error));
+  }
+
+  const { id } = await params;
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    return apiResponse.validationError(toError(new Error('File missing')));
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  const result = await updatePersonAvatar({
+    db: supabase,
+    personId: id,
+    bytes,
+    filename: file.name
+  });
+
+  if (result.error) return apiResponse.error(result.error);
+  return apiResponse.success(result.data);
+}

--- a/src/app/api/user/profile/avatar/route.ts
+++ b/src/app/api/user/profile/avatar/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+
+import { apiResponse } from '@/lib/api-response';
+import { validateAuthentication } from '@/lib/auth/validate-authentication';
+import { toError } from '@/lib/errors';
+import { updateUserAvatar } from '@/services/user/update-user-avatar';
+import { createClient } from '@/utils/supabase/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const authResult = await validateAuthentication(supabase);
+  if (authResult.error || !authResult.data) {
+    return apiResponse.unauthorized(toError(authResult.error));
+  }
+
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    return apiResponse.validationError(toError(new Error('File missing')));
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  const result = await updateUserAvatar({
+    db: supabase,
+    userId: authResult.data.id,
+    bytes,
+    filename: file.name
+  });
+
+  if (result.error) return apiResponse.error(result.error);
+  return apiResponse.success(result.data);
+}

--- a/src/app/app/settings/account/page.tsx
+++ b/src/app/app/settings/account/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { AvatarUpload } from '@/components/images/avatar-upload';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useUserProfile } from '@/hooks/use-user-profile';
+import { useState } from 'react';
+
+export default function AccountSettingsPage() {
+  const { data: profile, refetch } = useUserProfile();
+  const [first, setFirst] = useState(profile?.first_name || '');
+  const [last, setLast] = useState(profile?.last_name || '');
+
+  const handleAvatarUpload = async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    await fetch('/api/user/profile/avatar', { method: 'POST', body: formData });
+    refetch();
+  };
+
+  const handleSave = async () => {
+    await fetch('/api/person/' + profile?.id + '/details', {
+      method: 'PUT',
+      body: JSON.stringify({ field: 'first_name', value: first })
+    });
+  };
+
+  if (!profile) return null;
+  return (
+    <div className='mx-auto max-w-xl space-y-4 py-12'>
+      <h1 className='text-2xl font-bold'>Account</h1>
+      <div className='flex items-center gap-4'>
+        <AvatarUpload
+          name={profile.first_name || ''}
+          imageUrl={profile.avatar_url}
+          onUpload={handleAvatarUpload}
+          className='size-20'
+        />
+        <div className='flex-1 space-y-2'>
+          <Input value={first} onChange={(e) => setFirst(e.target.value)} />
+          <Input value={last} onChange={(e) => setLast(e.target.value)} />
+          <Button onClick={handleSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function SettingsPage() {
-  redirect('/app/settings/custom-fields');
+  redirect('/app/settings/account');
 }

--- a/src/components/images/avatar-upload.tsx
+++ b/src/components/images/avatar-upload.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { toast } from '@/components/ui/toast';
+
+interface AvatarUploadProps {
+  name: string;
+  imageUrl: string | null | undefined;
+  onUpload: (file: File) => Promise<void>;
+  className?: string;
+}
+
+export function AvatarUpload({ name, imageUrl, onUpload, className }: AvatarUploadProps) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (f.size > 6 * 1024 * 1024) {
+      toast.error('File size must be less than 6MB');
+      return;
+    }
+    setFile(f);
+    const reader = new FileReader();
+    reader.onload = () => setPreview(reader.result as string);
+    reader.readAsDataURL(f);
+    setOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (file) {
+      await onUpload(file);
+      setOpen(false);
+      setFile(null);
+    }
+  };
+
+  return (
+    <>
+      <Avatar className={className} onClick={() => fileRef.current?.click()}>
+        {imageUrl && <AvatarImage src={imageUrl} alt={name} />}
+        <AvatarFallback>{name[0]}</AvatarFallback>
+      </Avatar>
+      <input ref={fileRef} type='file' accept='image/*' className='hidden' onChange={handleSelect} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className='space-y-4'>
+          {preview && (
+            <img src={preview} alt='Preview' className='mx-auto max-h-60 rounded-full object-cover' />
+          )}
+          <div className='flex justify-end gap-2'>
+            <Button variant='outline' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/person/person-header.tsx
+++ b/src/components/person/person-header.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { GroupBadge } from '@/components/groups/group-badge';
 import { FollowUpIndicator } from '@/components/indicators/follow-up-indicator';
 import { UpdateFollowUpScoreButton } from '@/components/person/update-follow-up-score-button';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { AvatarUpload } from '@/components/images/avatar-upload';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { routes } from '@/lib/routes';
 import type { PersonGroup } from '@/types/custom';
@@ -31,9 +31,20 @@ export function PersonHeader({ person, groups = [], segment, taskCount }: Person
     <div className='px-5'>
       <div className='mt-4 flex flex-col gap-1 pb-2'>
         <div className='flex items-center gap-3 pb-0'>
-          <Avatar className='size-8'>
-            <AvatarFallback>{initials}</AvatarFallback>
-          </Avatar>
+          <AvatarUpload
+            name={person?.first_name || ''}
+            imageUrl={person?.avatar_url || null}
+            className='size-8'
+            onUpload={async (file) => {
+              const formData = new FormData();
+              formData.append('file', file);
+              await fetch(`/api/person/${person?.id}/avatar`, {
+                method: 'POST',
+                body: formData
+              });
+              router.refresh();
+            }}
+          />
           <h1 className='text-lg font-medium'>
             {person?.first_name} {person?.last_name}
           </h1>

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -8,6 +8,10 @@ import { cn } from '@/lib/utils';
 
 const SETTINGS_SECTIONS = [
   {
+    title: 'Account',
+    href: routes.settings.account()
+  },
+  {
     title: 'Custom Fields',
     href: routes.settings.customFields()
   },

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -24,6 +24,7 @@ const PERSON_SEGMENTS = {
 } as const;
 
 const SETTINGS_SEGMENTS = {
+  ACCOUNT: 'account',
   CUSTOM_FIELDS: 'custom-fields',
   INTEGRATIONS: 'integrations',
   IMPORTS: 'imports'
@@ -84,6 +85,7 @@ export const routes = {
   // Settings routes
   settings: {
     root: () => `${BASE_PATH}/${APP_SEGMENTS.SETTINGS}`,
+    account: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.ACCOUNT}`,
     customFields: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.CUSTOM_FIELDS}`,
     integrations: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.INTEGRATIONS}`,
     imports: () => `${routes.settings.root()}/${SETTINGS_SEGMENTS.IMPORTS}`

--- a/src/lib/schemas/database.ts
+++ b/src/lib/schemas/database.ts
@@ -511,6 +511,7 @@ export const personRowSchema = z.object({
   id: z.string(),
   last_name: z.string().nullable(),
   linkedin_public_id: z.string().nullable(),
+  avatar_url: z.string().nullable(),
   title: z.string().nullable(),
   updated_at: z.string(),
   user_id: z.string()
@@ -528,6 +529,7 @@ export const personInsertSchema = z.object({
   id: z.string().optional(),
   last_name: z.string().optional().nullable(),
   linkedin_public_id: z.string().optional().nullable(),
+  avatar_url: z.string().optional().nullable(),
   title: z.string().optional().nullable(),
   updated_at: z.string().optional(),
   user_id: z.string()
@@ -545,6 +547,7 @@ export const personUpdateSchema = z.object({
   id: z.string().optional(),
   last_name: z.string().optional().nullable(),
   linkedin_public_id: z.string().optional().nullable(),
+  avatar_url: z.string().optional().nullable(),
   title: z.string().optional().nullable(),
   updated_at: z.string().optional(),
   user_id: z.string().optional()

--- a/src/services/person/update-person-avatar.ts
+++ b/src/services/person/update-person-avatar.ts
@@ -1,0 +1,73 @@
+import { createError } from '@/lib/errors';
+import { errorLogger } from '@/lib/errors/error-logger';
+import { DBClient } from '@/types/database';
+import { ErrorType } from '@/types/errors';
+import { ServiceResponse } from '@/types/service-response';
+import { createServiceRoleClient } from '@/utils/supabase/service-role';
+
+export const ERRORS = {
+  AVATAR: {
+    MISSING_PERSON_ID: createError(
+      'missing_person_id',
+      ErrorType.VALIDATION_ERROR,
+      'Person ID is required',
+      'Please provide a person ID'
+    ),
+    UPLOAD_FAILED: createError(
+      'avatar_upload_failed',
+      ErrorType.DATABASE_ERROR,
+      'Failed to upload avatar',
+      'Unable to save avatar image'
+    )
+  }
+};
+
+export interface UpdatePersonAvatarParams {
+  db: DBClient;
+  personId: string;
+  bytes: Uint8Array;
+  filename: string;
+}
+
+export async function updatePersonAvatar({
+  db,
+  personId,
+  bytes,
+  filename
+}: UpdatePersonAvatarParams): Promise<ServiceResponse<string>> {
+  try {
+    if (!personId) {
+      return { data: null, error: ERRORS.AVATAR.MISSING_PERSON_ID };
+    }
+
+    const supabase = await createServiceRoleClient();
+    const path = `avatars/person-${personId}-${Date.now()}-${filename}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from('avatars')
+      .upload(path, bytes, { upsert: true, contentType: 'image/png' });
+
+    if (uploadError) {
+      const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: uploadError };
+      errorLogger.log(err);
+      return { data: null, error: err };
+    }
+
+    const { error: updateError } = await db
+      .from('person')
+      .update({ avatar_url: path })
+      .eq('id', personId);
+
+    if (updateError) {
+      const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: updateError };
+      errorLogger.log(err);
+      return { data: null, error: err };
+    }
+
+    return { data: path, error: null };
+  } catch (error) {
+    const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: error };
+    errorLogger.log(err);
+    return { data: null, error: err };
+  }
+}

--- a/src/services/user/update-user-avatar.ts
+++ b/src/services/user/update-user-avatar.ts
@@ -1,0 +1,73 @@
+import { createError } from '@/lib/errors';
+import { errorLogger } from '@/lib/errors/error-logger';
+import { DBClient } from '@/types/database';
+import { ErrorType } from '@/types/errors';
+import { ServiceResponse } from '@/types/service-response';
+import { createServiceRoleClient } from '@/utils/supabase/service-role';
+
+export const ERRORS = {
+  AVATAR: {
+    MISSING_USER_ID: createError(
+      'missing_user_id',
+      ErrorType.VALIDATION_ERROR,
+      'User ID is required',
+      'Please provide a user ID'
+    ),
+    UPLOAD_FAILED: createError(
+      'avatar_upload_failed',
+      ErrorType.DATABASE_ERROR,
+      'Failed to upload avatar',
+      'Unable to save avatar image'
+    )
+  }
+};
+
+export interface UpdateUserAvatarParams {
+  db: DBClient;
+  userId: string;
+  bytes: Uint8Array;
+  filename: string;
+}
+
+export async function updateUserAvatar({
+  db,
+  userId,
+  bytes,
+  filename
+}: UpdateUserAvatarParams): Promise<ServiceResponse<string>> {
+  try {
+    if (!userId) {
+      return { data: null, error: ERRORS.AVATAR.MISSING_USER_ID };
+    }
+
+    const supabase = await createServiceRoleClient();
+    const path = `avatars/${userId}-${Date.now()}-${filename}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from('avatars')
+      .upload(path, bytes, { upsert: true, contentType: 'image/png' });
+
+    if (uploadError) {
+      const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: uploadError };
+      errorLogger.log(err);
+      return { data: null, error: err };
+    }
+
+    const { error: updateError } = await db
+      .from('user_profile')
+      .update({ avatar_url: path })
+      .eq('user_id', userId);
+
+    if (updateError) {
+      const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: updateError };
+      errorLogger.log(err);
+      return { data: null, error: err };
+    }
+
+    return { data: path, error: null };
+  } catch (error) {
+    const err = { ...ERRORS.AVATAR.UPLOAD_FAILED, details: error };
+    errorLogger.log(err);
+    return { data: null, error: err };
+  }
+}

--- a/src/types/database/supabase.ts
+++ b/src/types/database/supabase.ts
@@ -550,6 +550,7 @@ export type Database = {
           id: string;
           last_name: string | null;
           linkedin_public_id: string | null;
+          avatar_url: string | null;
           title: string | null;
           updated_at: string;
           user_id: string;
@@ -566,6 +567,7 @@ export type Database = {
           id?: string;
           last_name?: string | null;
           linkedin_public_id?: string | null;
+          avatar_url?: string | null;
           title?: string | null;
           updated_at?: string;
           user_id: string;
@@ -582,6 +584,7 @@ export type Database = {
           id?: string;
           last_name?: string | null;
           linkedin_public_id?: string | null;
+          avatar_url?: string | null;
           title?: string | null;
           updated_at?: string;
           user_id?: string;


### PR DESCRIPTION
## Summary
- add avatar upload component and API endpoints
- add account settings page
- include avatars in person table types
- update settings navigation and routes
- allow uploading avatar on person header

## Testing
- `yarn lint` *(fails: next not found)*
- `yarn type-check` *(fails: missing modules)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634bd5f8ec832fb2a3035b00c029e2